### PR TITLE
Fixed japanese sentence search for multiple words for empty case

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -15,7 +15,6 @@
             <option value="$PROJECT_DIR$/app" />
           </set>
         </option>
-        <option name="resolveModulePerSourceSet" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/app/src/main/java/com/gaumala/openjisho/backend/TatoebaQuery.kt
+++ b/app/src/main/java/com/gaumala/openjisho/backend/TatoebaQuery.kt
@@ -14,7 +14,7 @@ sealed class TatoebaQuery {
             if (sanitizedText.contains(Regex("[a-zA-Z]")))
                 return English(sanitizedText)
 
-            return Japanese("%$sanitizedText%")
+            return Japanese(sanitizedText)
         }
     }
 }

--- a/app/src/main/java/com/gaumala/openjisho/backend/db/TatoebaQueryHelpers.kt
+++ b/app/src/main/java/com/gaumala/openjisho/backend/db/TatoebaQueryHelpers.kt
@@ -11,8 +11,14 @@ fun DictQueryDao.lookupSentencesWithJapaneseQuery(query: TatoebaQuery.Japanese,
     val sentenceKeys =
         lookupSentenceIdsMatchingIndices(query.matchText, limit, offset)
 
-    val sentences = lookupSentencesById(sentenceKeys)
-    val translations = lookupTranslationsById(sentenceKeys)
+    val sentences = if (sentenceKeys.isEmpty()) {
+        lookupSentencesLike(query.matchText, limit, offset)
+    } else {
+        lookupSentencesById(sentenceKeys)
+    }
+
+    val translations = lookupTranslationsById(sentences.map { it.id })
+
     // convert to map to filter out duplicates
     val translationsMap = translations.map { Pair(it.japaneseId, it) }
         .toMap()

--- a/app/src/main/java/com/gaumala/openjisho/backend/db/TatoebaQueryHelpers.kt
+++ b/app/src/main/java/com/gaumala/openjisho/backend/db/TatoebaQueryHelpers.kt
@@ -12,7 +12,7 @@ fun DictQueryDao.lookupSentencesWithJapaneseQuery(query: TatoebaQuery.Japanese,
         lookupSentenceIdsMatchingIndices(query.matchText, limit, offset)
 
     val sentences = if (sentenceKeys.isEmpty()) {
-        lookupSentencesLike(query.matchText, limit, offset)
+        lookupSentencesLike("%${query.matchText}%", limit, offset)
     } else {
         lookupSentencesById(sentenceKeys)
     }


### PR DESCRIPTION
Hi, this is a pretty cool app, I fixed the search a small issue where searching sentences using multiple japanese words yielded no result. I used the lookupSentencesLike query to fill out sentences in cases where there were no sentenceKeys added, and mapped the ids for the query in translation.

Cheers!